### PR TITLE
Ensure Connect layout fills frame height

### DIFF
--- a/Connect.html
+++ b/Connect.html
@@ -228,7 +228,7 @@ html,body{ margin:0; height:100%; background:var(--bg); font-family: Georgia, se
   display:flex;
   gap: var(--panel-gap);
   align-items:stretch;
-  min-height: calc(100% - 0px);
+  height: 100%;
   position: relative;
   z-index: 1;
   box-sizing: border-box;
@@ -241,10 +241,7 @@ html,body{ margin:0; height:100%; background:var(--bg); font-family: Georgia, se
   max-width: calc(100% - 360px);
   box-sizing: border-box;
   padding-right: 6px;
-  /* calculate available scrollable height:
-     frame height (100vh - 48) minus vertical padding inside frame (22*2) = 100vh - 92px
-  */
-  max-height: calc(100vh - 92px);
+  height: 100%;
   overflow-y: auto;
   scroll-behavior: smooth;
 }
@@ -257,6 +254,9 @@ html,body{ margin:0; height:100%; background:var(--bg); font-family: Georgia, se
   gap: var(--panel-gap);
   box-sizing: border-box;
   min-width: 240px;
+  height: 100%;
+  overflow-y: auto;
+  padding-right: 6px;
 }
 
 /* generic panel */
@@ -391,7 +391,7 @@ html,body{ margin:0; height:100%; background:var(--bg); font-family: Georgia, se
 .faq summary::-webkit-details-marker { display:none; }
 
 /* right column sizes (stacked) */
-.connect-right .panel { min-height: 120px; border-left: 6px solid var(--accent-line); }
+.connect-right .panel { min-height: 120px; border-left: 6px solid var(--accent-line); flex-shrink: 0; }
 .contact { min-height: 420px; }  /* tall left-of-right area */
 .discord { min-height: 100px; }
 .winston { min-height: 100px; }
@@ -414,13 +414,6 @@ html,body{ margin:0; height:100%; background:var(--bg); font-family: Georgia, se
   min-height: 0;                 /* critical: enables overflow inside flex items */
 }
 
-/* give the right column the same scroll treatment as the left */
-.connect-right {
-  max-height: calc(100vh - 92px);/* matches .connect-left */
-  overflow-y: auto;              /* add the scrollbar on the right */
-  padding-right: 6px;            /* visual parity with left column */
-}
-
 /* optional: match the custom scrollbar styling on the right column */
 .connect-right::-webkit-scrollbar { width: 12px; }
 .connect-right::-webkit-scrollbar-track { background: transparent; }
@@ -433,6 +426,7 @@ html,body{ margin:0; height:100%; background:var(--bg); font-family: Georgia, se
 /* keep mobile behavior unchanged (no column scrolling when stacked) */
 @media (max-width: 900px){
   .connect-right {
+    height: auto;
     max-height: none;
     overflow: visible;
     padding-right: 0;
@@ -443,8 +437,8 @@ html,body{ margin:0; height:100%; background:var(--bg); font-family: Georgia, se
 @media (max-width: 900px){
   .connect-inner { flex-direction: column; }
   .connect-left, .connect-right { min-width: 100%; max-width: 100%; }
-  .connect-left { max-height: none; overflow: visible; padding-right: 0; }
-  .connect-right { flex-direction: row; flex-wrap: wrap; gap: 12px; }
+  .connect-left { height: auto; max-height: none; overflow: visible; padding-right: 0; }
+  .connect-right { flex-direction: row; flex-wrap: wrap; gap: 12px; height: auto; }
   .connect-right .panel { flex: 1 1 48%; min-width: 140px; }
   .connect-frame { padding: 16px; border-width: calc(var(--frame-thickness) * 0.9); }
 }


### PR DESCRIPTION
## Summary
- stretch `connect-inner` and child columns to fully occupy the frame height
- allow columns to scroll while preserving mobile behavior
- prevent right column panels from shrinking and overlapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68adaee8b6b4832d999275ef8434cdf8