### PR TITLE
Refine Connect page visuals and footer layout

### DIFF
--- a/Connect.html
+++ b/Connect.html
@@ -3,6 +3,7 @@
   <div class="connect-wrap">
     <section class="connect-frame" aria-labelledby="connect-title" role="region">
       <h1 id="connect-title" class="visually-hidden">Connect</h1>
+      <div class="amethyst-overlay" aria-hidden="true"></div>
 
       <div class="connect-inner">
         <!-- LEFT 2/3 (scrollable content area) -->
@@ -20,19 +21,8 @@
                 <li>A link to their LinkedIn page</li>
               </ul>
 
-              <!-- Example grid (duplicate .crew-card blocks as you add producers) -->
               <div class="crew-list" aria-label="Producers">
-                <article class="crew-card">
-                  <img src="https://via.placeholder.com/240x240.png?text=Headshot" alt="Headshot of Producer Name" class="crew-headshot" loading="lazy" decoding="async">
-                  <div class="crew-meta">
-                    <h4 class="crew-name">Producer Name</h4>
-                    <p class="crew-title">Title — Majestic Media</p>
-                    <p class="crew-blurb">Short blurb outlining their role and goals at Majestic Media.</p>
-                    <p class="crew-link"><a href="#" target="_blank" rel="noopener">LinkedIn Profile</a></p>
-                  </div>
-                </article>
-
-                <!-- Add more .crew-card items here -->
+                <!-- Crew cards will be inserted here -->
               </div>
             </div>
           </div>
@@ -164,7 +154,10 @@
 /* color chosen from your RGB (120,0,120) -> #780078 */
 :root{
   --purple: #780078;
-  --purple-alpha: rgba(120,0,120,0.95);
+  --purple-r: 120;
+  --purple-g: 0;
+  --purple-b: 120;
+  --purple-alpha: rgba(var(--purple-r),var(--purple-g),var(--purple-b),0.95);
   --bg: #070006;                 /* darkened purple / near-black background */
   --frame-thickness: 20px;       /* rim thickness (per site rules) */
   --frame-inner-pad: 22px;       /* inner padding inside rim */
@@ -177,6 +170,10 @@
   --text-strong: #f6efe6;
   --text-muted: #e9e2d2;
   --accent-line: rgba(120,0,120,0.14);
+  --floor-gap: 28px;
+  --floor-line-opacity: 0.25;
+  --sheen-opacity: 0.32;
+  --glass-alpha: 0.23;
 }
 
 /* base / reset */
@@ -204,10 +201,23 @@ html,body{ margin:0; height:100%; background:var(--bg); font-family: Georgia, se
   box-sizing: border-box;
   position: relative;
   border-radius: 8px;
-  overflow: visible;
+  overflow: hidden;
   padding: var(--frame-inner-pad);    /* inner padding = 22px */
   border: var(--frame-thickness) solid var(--purple-alpha); /* visible rim = 20px */
-  background: linear-gradient(180deg, rgba(255,255,255,0.01), rgba(0,0,0,0.03));
+  background-image:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(var(--purple-r),var(--purple-g),var(--purple-b),var(--floor-line-opacity)) 0px,
+      rgba(var(--purple-r),var(--purple-g),var(--purple-b),var(--floor-line-opacity)) 1px,
+      rgba(0,0,0,0) 1px,
+      rgba(0,0,0,0) var(--floor-gap)
+    ),
+    linear-gradient(120deg, rgba(255,255,255,var(--sheen-opacity)) 0%, rgba(255,255,255,0) 35%),
+    linear-gradient(180deg, rgba(var(--purple-r),var(--purple-g),var(--purple-b),var(--glass-alpha)), rgba(20,0,20,0.22)),
+    radial-gradient(ellipse at 50% 80%, rgba(0,0,0,0) 0%, rgba(0,0,0,0.3) 85%);
+  background-repeat: repeat, no-repeat, no-repeat, no-repeat;
+  background-size: 100% auto, 100% 46%, cover, cover;
+  background-position: 0 0, 0 6%, center center, center bottom;
   /* subtle outer shadow */
   box-shadow: 0 12px 22px rgba(0,0,0,0.6), inset 0 2px 6px rgba(255,255,255,0.02);
 }
@@ -221,6 +231,20 @@ html,body{ margin:0; height:100%; background:var(--bg); font-family: Georgia, se
   pointer-events:none;
   box-shadow: inset 0 0 0 1px rgba(120,0,120,0.09);
   z-index:0;
+}
+
+.amethyst-overlay{
+  position:absolute;
+  inset:0;
+  pointer-events:none;
+  background-image:
+    linear-gradient(120deg, rgba(255,255,255,0.3) 0%, rgba(255,255,255,0) 35%),
+    url('https://www.transparenttextures.com/patterns/asfalt-light.png');
+  background-size: 100% 36%, 160px 160px;
+  background-blend-mode: overlay;
+  opacity: 0.25;
+  mix-blend-mode: overlay;
+  border-radius: inherit;
 }
 
 /* inner layout: left & right columns */
@@ -261,12 +285,12 @@ html,body{ margin:0; height:100%; background:var(--bg); font-family: Georgia, se
 
 /* generic panel */
 .panel{
-  background: linear-gradient(180deg, rgba(0,0,0,0.66), rgba(0,0,0,0.58));
+  background: none;
   border-radius: var(--radius);
   padding: 18px;
   color: var(--text-muted);
-  box-shadow: inset 0 6px 12px rgba(255,255,255,0.01), 0 6px 0 rgba(0,0,0,0.45);
-  border: 1px solid rgba(255,255,255,0.03);
+  box-shadow: none;
+  border: none;
   box-sizing: border-box;
   position: relative;
   z-index: 2;
@@ -381,17 +405,36 @@ html,body{ margin:0; height:100%; background:var(--bg); font-family: Georgia, se
 .form-note{ font-size:12px; opacity:0.85; }
 
 /* sizing tweaks to match your mock proportions */
-.meet-crew { margin-bottom: 8px; min-height: 420px; }
+.meet-crew { min-height: 420px; }
 .pitch { margin-top: 12px; }
 .faq { margin-top: 12px; min-height: 260px; }
 
 /* FAQ details styling */
-.faq details { margin-bottom: 8px; }
-.faq summary { cursor: pointer; font-weight:700; margin-bottom:6px; color: var(--text-strong); }
-.faq summary::-webkit-details-marker { display:none; }
+.faq details {
+  margin-bottom: 12px;
+  border-left: 2px solid var(--accent-line);
+  padding-left: 10px;
+}
+.faq summary {
+  cursor: pointer;
+  font-weight: 700;
+  margin-bottom: 6px;
+  color: var(--text-strong);
+  display: flex;
+  align-items: center;
+}
+.faq summary::before {
+  content: "+";
+  font-weight: 700;
+  margin-right: 8px;
+}
+.faq details[open] summary::before {
+  content: "\2212"; /* minus sign */
+}
+.faq summary::-webkit-details-marker { display: none; }
 
 /* right column sizes (stacked) */
-.connect-right .panel { min-height: 120px; border-left: 6px solid var(--accent-line); flex-shrink: 0; }
+.connect-right .panel { min-height: 120px; flex-shrink: 0; }
 .contact { min-height: 420px; }  /* tall left-of-right area */
 .discord { min-height: 100px; }
 .winston { min-height: 100px; }

--- a/Footer.html
+++ b/Footer.html
@@ -1,43 +1,26 @@
 <!-- ======== GLASSY SAPPHIRE FOOTER (Squarespace Code Block) ======== -->
 <div id="mm-glass-footer" role="contentinfo" aria-label="Site Footer">
   <div class="mmf-inner">
-    <!-- LEFT: Search (logo instead of magnifier) -->
-    <form class="mmf-search" role="search" action="/search" method="get" aria-label="Site Search">
-      <img class="mmf-brandmark" 
-           src="https://static1.squarespace.com/static/6891a6f0dcd941394db83fc9/t/68ad472d208b9736ab8d4e0f/1756186413963/1000171755.jpg" 
-           alt="Site logo" width="28" height="28" />
-      <input type="text" name="q" placeholder="Search…" aria-label="Search the site">
-    </form>
+    <!-- LEFT: Brand title -->
+    <div class="mmf-brand">
+      <a href="https://www.majesticmediastudios.com/">Majestic Media Studios</a>
+    </div>
 
-    <!-- CENTER: Social icons -->
+    <!-- RIGHT: Social icons -->
     <nav class="mmf-social" aria-label="Social links">
-      <a class="mmf-ic" href="https://youtube.com" target="_blank" rel="noopener" aria-label="YouTube" title="YouTube">
-        <!-- YouTube SVG -->
-        <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M23.5 6.2a3.1 3.1 0 0 0-2.2-2.2C19.4 3.5 12 3.5 12 3.5s-7.4 0-9.3.5A3.1 3.1 0 0 0 .5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3.1 3.1 0 0 0 2.2 2.2c1.9.5 9.3.5 9.3.5s7.4 0 9.3-.5a3.1 3.1 0 0 0 2.2-2.2c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.6 15.5v-7l6.2 3.5-6.2 3.5z"/></svg>
+      <a class="mmf-ic" href="https://discord.com" target="_blank" rel="noopener" aria-label="Discord" title="Discord">
+        <img src="https://static1.squarespace.com/static/6891a6f0dcd941394db83fc9/t/68adc4d78ba70d36351a26ed/1756218583815/1000171755.jpg" alt="Discord" />
       </a>
-
-      <!-- Facebook (your uploaded white icon) -->
-      <a class="mmf-ic" href="https://facebook.com" target="_blank" rel="noopener" aria-label="Facebook" title="Facebook">
-        <img src="https://static1.squarespace.com/static/6891a6f0dcd941394db83fc9/t/68adb5bc12c38c08b732445a/1756214717002/1000171757.jpg" 
-             alt="" width="26" height="26" />
+      <a class="mmf-ic" href="mailto:demo@example.com" target="_blank" rel="noopener" aria-label="Email" title="Email">
+        <img src="https://static1.squarespace.com/static/6891a6f0dcd941394db83fc9/t/68adc5345ba0f534a9893396/1756218676422/1000171756.jpg" alt="Email" />
       </a>
-
-      <a class="mmf-ic" href="https://discord.gg/your-invite" target="_blank" rel="noopener" aria-label="Discord" title="Discord">
-        <!-- Discord SVG -->
-        <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M20.3 4.4A17 17 0 0 0 15.9 3l-.2.5a16 16 0 0 0-7.4 0L8.1 3A17 17 0 0 0 3.7 4.4c-1.1 1.6-1.9 3.3-2.4 5.1a23.8 23.8 0 0 0-.3 9.9 17.8 17.8 0 0 0 5.6 1.8l.6-.8c-1.5-.5-2.9-1.3-4.2-2.3l.9-.7c2.6 1.9 5.7 3 8.9 3s6.3-1.1 8.9-3l.9.7c-1.3 1-2.7 1.8-4.2 2.3l.6.8c2-.3 3.9-.9 5.6-1.8.4-3.2-.1-6.5-1.5-9.5-.5-1.8-1.3-3.5-2.4-5.1zM8.8 14.7c-1.2 0-2.1-1.1-2.1-2.4s1-2.4 2.1-2.4 2.1 1.1 2.1 2.4-1 2.4-2.1 2.4zm6.4 0c-1.2 0-2.1-1.1-2.1-2.4s1-2.4 2.1-2.4 2.1 1.1 2.1 2.4-1 2.4-2.1 2.4z"/></svg>
-      </a>
-
       <a class="mmf-ic" href="https://reddit.com" target="_blank" rel="noopener" aria-label="Reddit" title="Reddit">
-        <!-- Reddit SVG -->
-        <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M22 12a3 3 0 0 0-5.1-2 9 9 0 0 0-4.4-1.2l.8-3.6 2.5.6a2 2 0 1 0 .4-1.4l-3.3-.8a.8.8 0 0 0-1 .6l-1 4.3a9 9 0 0 0-4.5 1.2A3 3 0 1 0 2 12v.1a4.8 4.8 0 0 0 0 .7c0 3.3 4.5 6 10 6s10-2.7 10-6c0-.2 0-.5-.1-.7V12Zm-14.4.8a1.6 1.6 0 1 1 0-3.2 1.6 1.6 0 0 1 0 3.2Zm8.8 0a1.6 1.6 0 1 1 0-3.2 1.6 1.6 0 0 1 0 3.2ZM12 18.2c-2.1 0-3.9-.6-5.2-1.5a.6.6 0 0 1 .7-.9c1 .8 2.6 1.3 4.5 1.3s3.4-.5 4.5-1.3a.6.6 0 1 1 .7.9c-1.3.9-3.1 1.5-5.2 1.5Z"/></svg>
+        <img src="https://static1.squarespace.com/static/6891a6f0dcd941394db83fc9/t/68adc57a6efa39627aadb6cd/1756218746561/1000171758.jpg" alt="Reddit" />
+      </a>
+      <a class="mmf-ic" href="https://youtube.com" target="_blank" rel="noopener" aria-label="YouTube" title="YouTube">
+        <img src="https://static1.squarespace.com/static/6891a6f0dcd941394db83fc9/t/68adc5bc5948c90210848618/1756218812026/1000171759.jpg" alt="YouTube" />
       </a>
     </nav>
-
-    <!-- RIGHT: Winston chat button -->
-    <button class="mmf-winston" id="mmfWinston" aria-label="Open Winston chat" title="Chat with Winston">
-      <span class="winston-gem" aria-hidden="true"></span>
-      <span class="winston-label">Winston</span>
-    </button>
   </div>
 </div>
 
@@ -67,6 +50,7 @@ body{ padding-bottom: var(--footer-h); }
   height: var(--footer-h);
   z-index: var(--z-footer);
   color: var(--text);
+  margin-top:0;
   /* Sapphire glass: translucent + blur + inner/outer glow */
   background: linear-gradient(180deg, rgba(255,255,255,.12), rgba(0,0,0,.18)) 0 0 / cover,
               var(--sapphire-12);
@@ -95,43 +79,27 @@ body{ padding-bottom: var(--footer-h); }
   margin: 0 auto;
   height: 100%;
   padding: 6px 18px;
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: 14px;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:14px;
 }
 
-/* ========== Search (logo left) ========== */
-.mmf-search{
-  position: relative;
-  display: flex;
-  align-items: center;
-  max-width: 520px;
+/* ========== Brand Title ========== */
+.mmf-brand{
+  display:flex;
+  align-items:center;
 }
-.mmf-brandmark{
-  position:absolute;
-  left: 10px;
-  width: 28px; height: 28px;
-  border-radius: 6px;
-  object-fit: cover;
-  filter: drop-shadow(0 1px 2px rgba(0,0,0,.45));
+.mmf-brand a{
+  color:#fff;
+  text-decoration:none;
+  font-weight:700;
+  font-size:1rem;
 }
-.mmf-search input{
-  width: 100%;
-  height: 38px;
-  padding: 0 12px 0 46px;             /* room for logo */
-  border-radius: 10px;
-  border: 1px solid rgba(255,255,255,.18);
-  background: linear-gradient(180deg, rgba(255,255,255,.14), rgba(0,0,0,.16));
-  color: #fff;
-  outline: none;
-  box-shadow: inset 0 2px 6px rgba(0,0,0,.35), 0 2px 8px rgba(0,0,0,.25);
-}
-.mmf-search input::placeholder{ color: rgba(255,255,255,.85); }
 
 /* ========== Social ========== */
 .mmf-social{
-  display:flex; align-items:center; justify-content:center; gap:16px;
+  display:flex; align-items:center; gap:16px;
 }
 .mmf-ic{
   display:inline-flex; align-items:center; justify-content:center;
@@ -144,79 +112,16 @@ body{ padding-bottom: var(--footer-h); }
 .mmf-ic img, .mmf-ic svg{ width: 26px; height: 26px; display:block; }
 .mmf-ic:hover{ transform: translateY(-1px) scale(1.06); background-color: rgba(255,255,255,.06); }
 
-/* ========== Winston ========== */
-.mmf-winston{
-  margin-left: auto;
-  display:flex; align-items:center; justify-content:flex-end; gap:10px;
-  background: transparent; color:#fff; border:0; cursor:pointer;
-  padding: 0; line-height:1;
-}
-.winston-label{ font-weight:700; letter-spacing:.2px; }
-.winston-gem{
-  --gem-size: 34px;
-  width: var(--gem-size); height: var(--gem-size);
-  position: relative;
-  display:inline-block;
-  filter: drop-shadow(0 2px 6px rgba(0,0,0,.45));
-  /* hex via clip-path */
-  clip-path: polygon(25% 6%, 75% 6%, 100% 50%, 75% 94%, 25% 94%, 0% 50%);
-  background: radial-gradient(ellipse at 50% 45%, #3dff7a 0%, #15c75a 45%, #0aa24a 70%, #067b36 100%);
-  animation: gemSpin 7s linear infinite, gemPulse 2.2s ease-in-out infinite;
-}
-.winston-gem::after{
-  /* glossy facet highlight */
-  content:"";
-  position:absolute; inset: 0;
-  clip-path: polygon(25% 6%, 75% 6%, 100% 50%, 75% 70%, 25% 70%, 0% 50%);
-  background: linear-gradient(180deg, rgba(255,255,255,.28), rgba(255,255,255,0) 65%);
-  mix-blend-mode: screen; opacity:.9;
-}
-
-/* Winston animations */
-@keyframes gemSpin { to { transform: rotate(360deg); } }
-@keyframes gemPulse {
-  0%,100% { box-shadow: 0 0 10px rgba(61,255,122,.5), inset 0 0 12px rgba(255,255,255,.15); }
-  50%     { box-shadow: 0 0 18px rgba(61,255,122,.9), inset 0 0 18px rgba(255,255,255,.25); }
-}
-
 /* ========== Responsive ========== */
 @media (max-width: 900px){
   .mmf-inner{ gap:10px; }
   .mmf-ic{ width:32px; height:32px; }
   .mmf-ic img, .mmf-ic svg{ width:24px; height:24px; }
-  .winston-label{ display:none; }         /* icon-only on small screens */
 }
 @media (max-width: 700px){
   #mm-glass-footer{ height: var(--footer-h-m); }
-  .mmf-search input{ height: 36px; }
-  .mmf-brandmark{ width:26px; height:26px; }
   .mmf-social{ gap:12px; }
 }
 </style>
 
-<script>
-/* Optional behavior for Winston (demo):
-   - Click once: “active” state (faster spin & pulse)
-   - Click again: return to idle
-   Replace the click handler with your chat launcher later.
-*/
-(function(){
-  const btn = document.getElementById('mmfWinston');
-  const gem = btn?.querySelector('.winston-gem');
-  if(!btn || !gem) return;
-
-  let active = false;
-  btn.addEventListener('click', function(){
-    active = !active;
-    if(active){
-      gem.style.animation = 'gemSpin 3.2s linear infinite, gemPulse 1.2s ease-in-out infinite';
-      // TODO: launch your chat widget here instead of just animating:
-      // window.YourChat?.open?.();
-    }else{
-      gem.style.animation = 'gemSpin 7s linear infinite, gemPulse 2.2s ease-in-out infinite';
-      // window.YourChat?.close?.();
-    }
-  });
-})();
-</script>
 <!-- ======== /END FOOTER ======== -->


### PR DESCRIPTION
## Summary
- Brighten Connect frame background and remove placeholder crew card
- Simplify footer: remove chatbot, add brand link, and placeholder social icons
- Make FAQ entries clearer with left borders and plus/minus icons

## Testing
- `npm test` (fails: Could not read package.json: ENOENT)


------
https://chatgpt.com/codex/tasks/task_b_68adbaee09e0832dabe13631b1b8e175